### PR TITLE
print versions when spm info not specify version

### DIFF
--- a/lib/info.js
+++ b/lib/info.js
@@ -63,10 +63,10 @@ function getPackageWithTag(body, args) {
 
 function getPackage(body, args) {
   if (!body.packages) return body;
-  var version = args.version || body.version ||
-    Object.keys(body.packages).sort(function(a, b){
-      return a < b;
-    })[0];
-  debug('get package version %s', version);
-  return body.packages[version];
+  if (args.version) {
+    debug('get package version %s', version);
+    return body.packages[args.version];
+  } else {
+    return body;
+  }
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -80,7 +80,8 @@ function* install(args, config) {
 function* installPackage(id, args, saveDeps) {
   delete args.name;
   var idObj = util.resolveid(id);
-  var pkgId = idObj.name + '@' + (idObj.version || 'stable');
+  idObj.version = idObj.version || 'stable';
+  var pkgId = idObj.name + '@' + (idObj.version);
   log.info('install', color.magenta(pkgId));
   debug('start install package %s', pkgId);
 

--- a/test/info.test.js
+++ b/test/info.test.js
@@ -32,11 +32,11 @@ describe('/lib/info.js', function() {
     var args = mockRequest.calls[0].arguments[0];
     args.url.should.eql('http://spmjs.io/repository/arale-cookie/');
     args.should.have.property('json');
-    res.should.eql(obj.packages['1.1.0']);
+    res.should.eql(obj);
   });
 
   it('should not packages info by name', function* () {
-    var obj = require(join(fixtures, 'package-with-name.json'));
+    var obj = require(join(fixtures, 'no-packages.json'));
     mockRequest.mock(function* () {
       /* jshint noyield: true */
       return {
@@ -46,13 +46,13 @@ describe('/lib/info.js', function() {
       };
     });
     var res = yield* info({
-      name: 'arale-cookie'
+      name: 'tmp'
     }, config);
     mockRequest.callCount.should.eql(1);
     var args = mockRequest.calls[0].arguments[0];
-    args.url.should.eql('http://spmjs.io/repository/arale-cookie/');
+    args.url.should.eql('http://spmjs.io/repository/tmp/');
     args.should.have.property('json');
-    res.should.eql(obj.packages['1.1.0']);
+    res.should.eql(obj);
   });
 
   it('should get info by name@version', function* () {
@@ -129,7 +129,8 @@ describe('/lib/info.js', function() {
       };
     });
     var res = yield* info({
-      name: 'tmp'
+      name: 'tmp',
+      tag: 'stable'
     }, config);
     mockRequest.callCount.should.eql(1);
     var args = mockRequest.calls[0].arguments[0];
@@ -153,7 +154,7 @@ describe('/lib/info.js', function() {
     mockRequest.callCount.should.eql(1);
     var args = mockRequest.calls[0].arguments[0];
     args.url.should.eql('http://spmjs.io/repository/tmp/');
-    res.should.eql(obj.packages['0.0.2']);
+    res.should.eql(obj);
   });
 
   it('should throw when statusCode>=500', function* () {


### PR DESCRIPTION
问题：`spm info jquery` 时未按期待输出 versions 信息。

原因：client.info 时，未传入 version 和 tag 信息时，应该返回整个包的信息，而不是某版本的信息。

修改后的逻辑为：
1. 返回所有 http://spmjs.io/repository/jquery/
   
   ```
   info({
    name: 'jquery'
   )};
   ```
2. 返回指定版本 http://spmjs.io/repository/jquery/2.0.0
   
   ```
   info({
    name: 'jquery',
    version: '2.0.0'
   )};
   ```
3. 返回指定 tag 的最新稳定版本 http://spmjs.io/repository/jquery/2.1.1
   
   ```
   info({
    name: 'jquery',
    tag: 'stable'
   )};
   ```
